### PR TITLE
Add new signal "href" for full url

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "summary": "History API in Elm",
     "repository": "https://github.com/elm-community/elm-history.git",
     "license": "BSD3",

--- a/src/History.elm
+++ b/src/History.elm
@@ -105,3 +105,16 @@ Paths are of the form: `/myPath.html` or `/users/4873/profile.html`
 -}
 path : Signal String
 path = Native.History.path
+
+{-| The current href value of the url. The value is updated
+whenever it is changed, either through interaction or code.
+This is the main way you can create single page applications.
+By incorporating the `href` as an input of your application,
+you are able to react to changes to these hrefs and route
+and re-route your pages accordingly in order to show the most
+appropriate information given the href.
+
+Hrefs are of the form: `https://localhost:1337/myPath.html`
+-}
+href : Signal String
+href = Native.History.href

--- a/src/Native/History.js
+++ b/src/Native/History.js
@@ -23,10 +23,14 @@ Elm.Native.History.make = function(localRuntime){
   // hash : Signal String
   var hash = NS.input('History.hash', window.location.hash);
 
+  // hash : Signal String
+  var href = NS.input('History.href', window.location.href);
+
   localRuntime.addListener([path.id, length.id], node, 'popstate', function getPath(event){
     localRuntime.notify(path.id, window.location.pathname);
     localRuntime.notify(length.id, window.history.length);
     localRuntime.notify(hash.id, window.location.hash);
+    localRuntime.notify(href.id, window.location.href);
   });
 
   localRuntime.addListener([hash.id], node, 'hashchange', function getHash(event){
@@ -41,7 +45,7 @@ Elm.Native.History.make = function(localRuntime){
         window.history.pushState({}, "", urlpath);
         localRuntime.notify(hash.id, window.location.hash);
         localRuntime.notify(length.id, window.history.length);
-
+        localRuntime.notify(href.id, window.location.href);
       },0);
       return callback(Task.succeed(Utils.Tuple0));
     });
@@ -55,6 +59,7 @@ Elm.Native.History.make = function(localRuntime){
         window.history.replaceState({}, "", urlpath);
         localRuntime.notify(hash.id, window.location.hash);
         localRuntime.notify(length.id, window.history.length);
+        localRuntime.notify(href.id, window.location.href);
       },0);
       return callback(Task.succeed(Utils.Tuple0));
     });
@@ -67,6 +72,7 @@ Elm.Native.History.make = function(localRuntime){
         window.history.go(n);
         localRuntime.notify(length.id, window.history.length);
         localRuntime.notify(hash.id, window.location.hash);
+        localRuntime.notify(href.id, window.location.href);
       }, 0);
       return callback(Task.succeed(Utils.Tuple0));
     });
@@ -78,7 +84,7 @@ Elm.Native.History.make = function(localRuntime){
       localRuntime.notify(hash.id, window.location.hash);
       window.history.back();
       localRuntime.notify(length.id, window.history.length);
-
+      localRuntime.notify(href.id, window.location.href);
     }, 0);
     return callback(Task.succeed(Utils.Tuple0));
   });
@@ -89,6 +95,7 @@ Elm.Native.History.make = function(localRuntime){
       window.history.forward();
       localRuntime.notify(length.id, window.history.length);
       localRuntime.notify(hash.id, window.location.hash);
+      localRuntime.notify(href.id, window.location.href);
     }, 0);
     return callback(Task.succeed(Utils.Tuple0));
   });
@@ -103,7 +110,8 @@ Elm.Native.History.make = function(localRuntime){
     back        : back,
     forward     : forward,
     length      : length,
-    hash        : hash
+    hash        : hash,
+    href        : href
   };
 
 };


### PR DESCRIPTION
This PR adds a new signal `href`, which is an alias for `window.location.href` and can be used to get the full URL with query string parameters. Fixes #4.
